### PR TITLE
Adds the possibility to pass a Specification to query not deleted items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .project
 .metadata
 .gradle
+.idea
+*.iml
 bin/
 tmp/
 *.tmp

--- a/src/main/java/com/kristijangeorgiev/softdelete/repository/SoftDeletesRepository.java
+++ b/src/main/java/com/kristijangeorgiev/softdelete/repository/SoftDeletesRepository.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.repository.NoRepositoryBean;
 import org.springframework.data.repository.PagingAndSortingRepository;
@@ -36,6 +37,18 @@ public interface SoftDeletesRepository<T, ID extends Serializable> extends Pagin
 	Iterable<T> findAllActive(Iterable<ID> ids);
 
 	T findOneActive(ID id);
+
+	Iterable<T> findActive(Specification<T> spec);
+
+	Iterable<T> findActive(Specification<T> spec, Sort sort);
+
+	Page<T> findActive(Specification<T> spec, Pageable pageable);
+
+	Iterable<T> findActive(Specification<T> spec, Iterable<ID> ids);
+
+	T findOneActive(Specification<T> spec);
+
+	T findOneActive(Specification<T> spec, ID id);
 
 	@Modifying
 	void softDelete(ID id);

--- a/src/main/java/com/kristijangeorgiev/softdelete/repository/SoftDeletesRepositoryImpl.java
+++ b/src/main/java/com/kristijangeorgiev/softdelete/repository/SoftDeletesRepositoryImpl.java
@@ -49,353 +49,408 @@ import org.springframework.util.Assert;
 import com.google.common.base.CaseFormat;
 
 /**
- * 
+ * @param <T>  the class of the entity
+ * @param <ID> the ID class of the entity
+ *             <p>
+ *             Custom implementation for soft deleting
  * @author Kristijan Georgiev
- *
- * @param <T>
- *            the class of the entity
- * @param <ID>
- *            the ID class of the entity
- * 
- *            Custom implementation for soft deleting
  */
 public class SoftDeletesRepositoryImpl<T, ID extends Serializable> extends SimpleJpaRepository<T, ID>
-		implements SoftDeletesRepository<T, ID> {
-
-	private final JpaEntityInformation<T, ?> entityInformation;
-	private final EntityManager em;
-	private final Class<T> domainClass;
-	private static final String DELETED_FIELD = "deletedOn";
-
-	public SoftDeletesRepositoryImpl(Class<T> domainClass, EntityManager em) {
-		super(domainClass, em);
-		this.em = em;
-		this.domainClass = domainClass;
-		this.entityInformation = JpaEntityInformationSupport.getEntityInformation(domainClass, em);
-	}
-
-	@Override
-	public Iterable<T> findAllActive() {
-		return super.findAll(notDeleted());
-	}
-
-	@Override
-	public Iterable<T> findAllActive(Sort sort) {
-		return super.findAll(notDeleted(), sort);
-	}
-
-	@Override
-	public Page<T> findAllActive(Pageable pageable) {
-		return super.findAll(notDeleted(), pageable);
-	}
-
-	@Override
-	public Iterable<T> findAllActive(Iterable<ID> ids) {
-		if (ids == null || !ids.iterator().hasNext())
-			return Collections.emptyList();
-
-		if (entityInformation.hasCompositeId()) {
-			List<T> results = new ArrayList<T>();
-
-			for (ID id : ids)
-				results.add(findOneActive(id));
-
-			return results;
-		}
-
-		ByIdsSpecification<T> specification = new ByIdsSpecification<T>(entityInformation);
-		TypedQuery<T> query = getQuery(Specifications.where(specification).and(notDeleted()), (Sort) null);
-
-		return query.setParameter(specification.parameter, ids).getResultList();
-	}
-
-	@Override
-	public T findOneActive(ID id) {
-		return super.findOne(
-				Specifications.where(new ByIdSpecification<T, ID>(entityInformation, id)).and(notDeleted()));
-	}
-
-	@Override
-	@Transactional
-	@SuppressWarnings("unchecked")
-	public <S extends T> S save(S entity) {
-		Set<ConstraintViolation<S>> constraintViolations = Validation.buildDefaultValidatorFactory().getValidator()
-				.validate(entity);
-
-		if (constraintViolations.size() > 0)
-			throw new ConstraintViolationException(constraintViolations.toString(), constraintViolations);
-
-		Class<?> entityClass = entity.getClass();
-		CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
-		CriteriaQuery<Object> criteriaQuery = criteriaBuilder.createQuery();
-		Root<?> root = criteriaQuery.from(entityClass);
-
-		List<Predicate> predicates = new ArrayList<Predicate>();
-
-		if (entityInformation.hasCompositeId()) {
-			for (String s : entityInformation.getIdAttributeNames())
-				predicates.add(criteriaBuilder.equal(root.<ID>get(s),
-						entityInformation.getCompositeIdAttributeValue(entityInformation.getId(entity), s)));
-
-			predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get(DELETED_FIELD), LocalDateTime.now()));
-
-			criteriaQuery.select(root).where(predicates.toArray(new Predicate[predicates.size()]));
-			TypedQuery<Object> typedQuery = em.createQuery(criteriaQuery);
-			List<Object> resultSet = typedQuery.getResultList();
-
-			if (resultSet.size() > 0) {
-				S result = (S) resultSet.get(0);
-				BeanUtils.copyProperties(entity, result, getNullPropertyNames(entity));
-				return (S) super.save(result);
-			}
-		}
-
-		if (entity.getClass().isAnnotationPresent(Table.class)) {
-			Annotation a = entity.getClass().getAnnotation(Table.class);
-
-			try {
-				UniqueConstraint[] uniqueConstraints = (UniqueConstraint[]) a.annotationType()
-						.getMethod("uniqueConstraints").invoke(a);
-
-				if (uniqueConstraints != null) {
-					for (UniqueConstraint uniqueConstraint : uniqueConstraints) {
-						Map<String, Object> data = new HashMap<>();
-
-						for (String name : uniqueConstraint.columnNames()) {
-							if (name.endsWith("_id"))
-								name = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL,
-										name.substring(0, name.length() - 3));
-
-							PropertyDescriptor pd = new PropertyDescriptor(name, entityClass);
-							Object value = pd.getReadMethod().invoke(entity);
-
-							if (value == null) {
-								data.clear();
-								break;
-							}
-
-							data.put(name, value);
-						}
-
-						if (!data.isEmpty())
-							for (Map.Entry<String, Object> entry : data.entrySet())
-								predicates.add(criteriaBuilder.equal(root.get(entry.getKey()), entry.getValue()));
-					}
-
-					if (predicates.isEmpty())
-						return super.save(entity);
-
-					predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get(DELETED_FIELD), LocalDateTime.now()));
-
-					criteriaQuery.select(root).where(predicates.toArray(new Predicate[predicates.size()]));
-					TypedQuery<Object> typedQuery = em.createQuery(criteriaQuery);
-					List<Object> resultSet = typedQuery.getResultList();
-
-					if (resultSet.size() > 0) {
-						S result = (S) resultSet.get(0);
-
-						BeanUtils.copyProperties(entity,
-								result, Stream
-										.concat(Arrays.stream(getNullPropertyNames(entity)),
-												Arrays.stream(
-														new String[] { entityInformation.getIdAttribute().getName() }))
-										.toArray(String[]::new));
-
-						return (S) super.save(result);
-					}
-				}
-			} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException
-					| NoSuchMethodException | SecurityException | IntrospectionException e) {
-				e.printStackTrace();
-			}
-		}
-		return super.save(entity);
-	}
-
-	@Override
-	@Transactional
-	public <S extends T> S saveAndFlush(S entity) {
-
-		S result = this.save(entity);
-		flush();
-
-		return result;
-	}
-
-	@Override
-	@Transactional
-	public <S extends T> List<S> save(Iterable<S> entities) {
-
-		List<S> result = new ArrayList<S>();
-
-		if (entities == null) {
-			return result;
-		}
-
-		for (S entity : entities) {
-			result.add(this.save(entity));
-		}
-
-		return result;
-	}
-
-	public static String[] getNullPropertyNames(Object source) {
-		final BeanWrapper src = new BeanWrapperImpl(source);
-		PropertyDescriptor[] pds = src.getPropertyDescriptors();
-
-		Set<String> propertyNames = new HashSet<String>();
-		for (PropertyDescriptor pd : pds)
-			if (!pd.getName().equals(DELETED_FIELD) && src.getPropertyValue(pd.getName()) == null)
-				propertyNames.add(pd.getName());
-
-		return propertyNames.toArray(new String[propertyNames.size()]);
-	}
-
-	@Override
-	@Transactional
-	public void softDelete(ID id) {
-		Assert.notNull(id, "The given id must not be null!");
-		softDelete(id, LocalDateTime.now());
-	}
-
-	@Override
-	@Transactional
-	public void softDelete(T entity) {
-		Assert.notNull(entity, "The entity must not be null!");
-		softDelete(entity, LocalDateTime.now());
-	}
-
-	@Override
-	@Transactional
-	public void softDelete(Iterable<? extends T> entities) {
-		Assert.notNull(entities, "The given Iterable of entities not be null!");
-		for (T entity : entities)
-			softDelete(entity);
-	}
-
-	@Override
-	@Transactional
-	public void softDeleteAll() {
-		for (T entity : findAllActive())
-			softDelete(entity);
-	}
-
-	@Override
-	@Transactional
-	public void scheduleSoftDelete(ID id, LocalDateTime localDateTime) {
-		softDelete(id, localDateTime);
-	}
-
-	@Override
-	@Transactional
-	public void scheduleSoftDelete(T entity, LocalDateTime localDateTime) {
-		softDelete(entity, localDateTime);
-	}
-
-	private void softDelete(ID id, LocalDateTime localDateTime) {
-		Assert.notNull(id, "The given id must not be null!");
-
-		T entity = findOneActive(id);
-
-		if (entity == null)
-			throw new EmptyResultDataAccessException(
-					String.format("No %s entity with id %s exists!", entityInformation.getJavaType(), id), 1);
-
-		softDelete(entity, localDateTime);
-	}
-
-	private void softDelete(T entity, LocalDateTime localDateTime) {
-		Assert.notNull(entity, "The entity must not be null!");
-
-		CriteriaBuilder cb = em.getCriteriaBuilder();
-
-		CriteriaUpdate<T> update = cb.createCriteriaUpdate((Class<T>) domainClass);
-
-		Root<T> root = update.from((Class<T>) domainClass);
-
-		update.set(DELETED_FIELD, localDateTime);
-
-		final List<Predicate> predicates = new ArrayList<Predicate>();
-
-		if (entityInformation.hasCompositeId()) {
-			for (String s : entityInformation.getIdAttributeNames())
-				predicates.add(cb.equal(root.<ID>get(s),
-						entityInformation.getCompositeIdAttributeValue(entityInformation.getId(entity), s)));
-			update.where(cb.and(predicates.toArray(new Predicate[predicates.size()])));
-		} else
-			update.where(cb.equal(root.<ID>get(entityInformation.getIdAttribute().getName()),
-					entityInformation.getId(entity)));
-
-		em.createQuery(update).executeUpdate();
-	}
-
-	public long countActive() {
-		return super.count(notDeleted());
-	}
-
-	@Override
-	public boolean existsActive(ID id) {
-		Assert.notNull(id, "The entity must not be null!");
-		return findOneActive(id) != null ? true : false;
-	}
-
-	private static final class ByIdSpecification<T, ID extends Serializable> implements Specification<T> {
-
-		private final JpaEntityInformation<T, ?> entityInformation;
-		private final ID id;
-
-		public ByIdSpecification(JpaEntityInformation<T, ?> entityInformation, ID id) {
-			this.entityInformation = entityInformation;
-			this.id = id;
-		}
-
-		@Override
-		public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
-			final List<Predicate> predicates = new ArrayList<Predicate>();
-			if (entityInformation.hasCompositeId()) {
-				for (String s : entityInformation.getIdAttributeNames())
-					predicates.add(cb.equal(root.<ID>get(s), entityInformation.getCompositeIdAttributeValue(id, s)));
-
-				return cb.and(predicates.toArray(new Predicate[predicates.size()]));
-			}
-			return cb.equal(root.<ID>get(entityInformation.getIdAttribute().getName()), id);
-		}
-	}
-
-	@SuppressWarnings("rawtypes")
-	private static final class ByIdsSpecification<T> implements Specification<T> {
-
-		private final JpaEntityInformation<T, ?> entityInformation;
-
-		ParameterExpression<Iterable> parameter;
-
-		public ByIdsSpecification(JpaEntityInformation<T, ?> entityInformation) {
-			this.entityInformation = entityInformation;
-		}
-
-		@Override
-		public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
-			Path<?> path = root.get(entityInformation.getIdAttribute());
-			parameter = cb.parameter(Iterable.class);
-			return path.in(parameter);
-		}
-	}
-
-	private static final class DeletedIsNull<T> implements Specification<T> {
-		@Override
-		public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
-			return cb.isNull(root.<LocalDateTime>get(DELETED_FIELD));
-		}
-	}
-
-	private static final class DeletedTimeGreatherThanNow<T> implements Specification<T> {
-		@Override
-		public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
-			return cb.greaterThan(root.<LocalDateTime>get(DELETED_FIELD), LocalDateTime.now());
-		}
-	}
-
-	private static final <T> Specification<T> notDeleted() {
-		return Specifications.where(new DeletedIsNull<T>()).or(new DeletedTimeGreatherThanNow<T>());
-	}
+        implements SoftDeletesRepository<T, ID> {
+
+    private final JpaEntityInformation<T, ?> entityInformation;
+    private final EntityManager em;
+    private final Class<T> domainClass;
+    private static final String DELETED_FIELD = "deletedOn";
+
+    public SoftDeletesRepositoryImpl(Class<T> domainClass, EntityManager em) {
+        super(domainClass, em);
+        this.em = em;
+        this.domainClass = domainClass;
+        this.entityInformation = JpaEntityInformationSupport.getEntityInformation(domainClass, em);
+    }
+
+    @Override
+    public Iterable<T> findAllActive() {
+        return super.findAll(notDeleted());
+    }
+
+    @Override
+    public Iterable<T> findAllActive(Sort sort) {
+        return super.findAll(notDeleted(), sort);
+    }
+
+    @Override
+    public Page<T> findAllActive(Pageable pageable) {
+        return super.findAll(notDeleted(), pageable);
+    }
+
+    @Override
+    public Iterable<T> findAllActive(Iterable<ID> ids) {
+        if (ids == null || !ids.iterator().hasNext())
+            return Collections.emptyList();
+
+        if (entityInformation.hasCompositeId()) {
+            List<T> results = new ArrayList<T>();
+
+            for (ID id : ids)
+                results.add(findOneActive(id));
+
+            return results;
+        }
+
+        ByIdsSpecification<T> specification = new ByIdsSpecification<T>(entityInformation);
+        TypedQuery<T> query = getQuery(Specifications.where(specification).and(notDeleted()), (Sort) null);
+
+        return query.setParameter(specification.parameter, ids).getResultList();
+    }
+
+    @Override
+    public T findOneActive(ID id) {
+        return super.findOne(
+                Specifications.where(new ByIdSpecification<T, ID>(entityInformation, id)).and(notDeleted()));
+    }
+
+    @Override
+    public Iterable<T> findActive(Specification<T> spec) {
+        return super.findAll(composeWhereNotDeleted(spec));
+    }
+
+    @Override
+    public Iterable<T> findActive(Specification<T> spec, Sort sort) {
+        return super.findAll(composeWhereNotDeleted(spec), sort);
+    }
+
+    @Override
+    public Page<T> findActive(Specification<T> spec, Pageable pageable) {
+        return super.findAll(composeWhereNotDeleted(spec), pageable);
+    }
+
+    @Override
+    public Iterable<T> findActive(Specification<T> spec, Iterable<ID> ids) {
+        if (ids == null || !ids.iterator().hasNext())
+            return Collections.emptyList();
+
+        if (entityInformation.hasCompositeId()) {
+            List<T> results = new ArrayList<T>();
+
+            for (ID id : ids)
+                results.add(findOneActive(spec, id));
+
+            return results;
+        }
+
+        ByIdsSpecification<T> specification = new ByIdsSpecification<T>(entityInformation);
+        TypedQuery<T> query = getQuery(
+                Specifications.where(spec)
+                        .and(Specifications.where(specification))
+                        .and(notDeleted()),
+                (Sort) null);
+
+        return query.setParameter(specification.parameter, ids).getResultList();
+    }
+
+    @Override
+    public T findOneActive(Specification<T> spec, ID id) {
+        return super.findOne(
+                Specifications.where(spec)
+                        .and(new ByIdSpecification<T, ID>(entityInformation, id))
+                        .and(notDeleted()));
+    }
+
+
+    @Override
+    public T findOneActive(Specification<T> spec) {
+        return super.findOne(composeWhereNotDeleted(spec));
+    }
+
+
+    @Override
+    @Transactional
+    @SuppressWarnings("unchecked")
+    public <S extends T> S save(S entity) {
+        Set<ConstraintViolation<S>> constraintViolations = Validation.buildDefaultValidatorFactory().getValidator()
+                .validate(entity);
+
+        if (constraintViolations.size() > 0)
+            throw new ConstraintViolationException(constraintViolations.toString(), constraintViolations);
+
+        Class<?> entityClass = entity.getClass();
+        CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+        CriteriaQuery<Object> criteriaQuery = criteriaBuilder.createQuery();
+        Root<?> root = criteriaQuery.from(entityClass);
+
+        List<Predicate> predicates = new ArrayList<Predicate>();
+
+        if (entityInformation.hasCompositeId()) {
+            for (String s : entityInformation.getIdAttributeNames())
+                predicates.add(criteriaBuilder.equal(root.<ID>get(s),
+                        entityInformation.getCompositeIdAttributeValue(entityInformation.getId(entity), s)));
+
+            predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get(DELETED_FIELD), LocalDateTime.now()));
+
+            criteriaQuery.select(root).where(predicates.toArray(new Predicate[predicates.size()]));
+            TypedQuery<Object> typedQuery = em.createQuery(criteriaQuery);
+            List<Object> resultSet = typedQuery.getResultList();
+
+            if (resultSet.size() > 0) {
+                S result = (S) resultSet.get(0);
+                BeanUtils.copyProperties(entity, result, getNullPropertyNames(entity));
+                return (S) super.save(result);
+            }
+        }
+
+        if (entity.getClass().isAnnotationPresent(Table.class)) {
+            Annotation a = entity.getClass().getAnnotation(Table.class);
+
+            try {
+                UniqueConstraint[] uniqueConstraints = (UniqueConstraint[]) a.annotationType()
+                        .getMethod("uniqueConstraints").invoke(a);
+
+                if (uniqueConstraints != null) {
+                    for (UniqueConstraint uniqueConstraint : uniqueConstraints) {
+                        Map<String, Object> data = new HashMap<>();
+
+                        for (String name : uniqueConstraint.columnNames()) {
+                            if (name.endsWith("_id"))
+                                name = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL,
+                                        name.substring(0, name.length() - 3));
+
+                            PropertyDescriptor pd = new PropertyDescriptor(name, entityClass);
+                            Object value = pd.getReadMethod().invoke(entity);
+
+                            if (value == null) {
+                                data.clear();
+                                break;
+                            }
+
+                            data.put(name, value);
+                        }
+
+                        if (!data.isEmpty())
+                            for (Map.Entry<String, Object> entry : data.entrySet())
+                                predicates.add(criteriaBuilder.equal(root.get(entry.getKey()), entry.getValue()));
+                    }
+
+                    if (predicates.isEmpty())
+                        return super.save(entity);
+
+                    predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get(DELETED_FIELD), LocalDateTime.now()));
+
+                    criteriaQuery.select(root).where(predicates.toArray(new Predicate[predicates.size()]));
+                    TypedQuery<Object> typedQuery = em.createQuery(criteriaQuery);
+                    List<Object> resultSet = typedQuery.getResultList();
+
+                    if (resultSet.size() > 0) {
+                        S result = (S) resultSet.get(0);
+
+                        BeanUtils.copyProperties(entity,
+                                result, Stream
+                                        .concat(Arrays.stream(getNullPropertyNames(entity)),
+                                                Arrays.stream(
+                                                        new String[]{entityInformation.getIdAttribute().getName()}))
+                                        .toArray(String[]::new));
+
+                        return (S) super.save(result);
+                    }
+                }
+            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException
+                    | NoSuchMethodException | SecurityException | IntrospectionException e) {
+                e.printStackTrace();
+            }
+        }
+        return super.save(entity);
+    }
+
+    @Override
+    @Transactional
+    public <S extends T> S saveAndFlush(S entity) {
+
+        S result = this.save(entity);
+        flush();
+
+        return result;
+    }
+
+    @Override
+    @Transactional
+    public <S extends T> List<S> save(Iterable<S> entities) {
+
+        List<S> result = new ArrayList<S>();
+
+        if (entities == null) {
+            return result;
+        }
+
+        for (S entity : entities) {
+            result.add(this.save(entity));
+        }
+
+        return result;
+    }
+
+    public static String[] getNullPropertyNames(Object source) {
+        final BeanWrapper src = new BeanWrapperImpl(source);
+        PropertyDescriptor[] pds = src.getPropertyDescriptors();
+
+        Set<String> propertyNames = new HashSet<String>();
+        for (PropertyDescriptor pd : pds)
+            if (!pd.getName().equals(DELETED_FIELD) && src.getPropertyValue(pd.getName()) == null)
+                propertyNames.add(pd.getName());
+
+        return propertyNames.toArray(new String[propertyNames.size()]);
+    }
+
+    @Override
+    @Transactional
+    public void softDelete(ID id) {
+        Assert.notNull(id, "The given id must not be null!");
+        softDelete(id, LocalDateTime.now());
+    }
+
+    @Override
+    @Transactional
+    public void softDelete(T entity) {
+        Assert.notNull(entity, "The entity must not be null!");
+        softDelete(entity, LocalDateTime.now());
+    }
+
+    @Override
+    @Transactional
+    public void softDelete(Iterable<? extends T> entities) {
+        Assert.notNull(entities, "The given Iterable of entities not be null!");
+        for (T entity : entities)
+            softDelete(entity);
+    }
+
+    @Override
+    @Transactional
+    public void softDeleteAll() {
+        for (T entity : findAllActive())
+            softDelete(entity);
+    }
+
+    @Override
+    @Transactional
+    public void scheduleSoftDelete(ID id, LocalDateTime localDateTime) {
+        softDelete(id, localDateTime);
+    }
+
+    @Override
+    @Transactional
+    public void scheduleSoftDelete(T entity, LocalDateTime localDateTime) {
+        softDelete(entity, localDateTime);
+    }
+
+    private void softDelete(ID id, LocalDateTime localDateTime) {
+        Assert.notNull(id, "The given id must not be null!");
+
+        T entity = findOneActive(id);
+
+        if (entity == null)
+            throw new EmptyResultDataAccessException(
+                    String.format("No %s entity with id %s exists!", entityInformation.getJavaType(), id), 1);
+
+        softDelete(entity, localDateTime);
+    }
+
+    private void softDelete(T entity, LocalDateTime localDateTime) {
+        Assert.notNull(entity, "The entity must not be null!");
+
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+
+        CriteriaUpdate<T> update = cb.createCriteriaUpdate((Class<T>) domainClass);
+
+        Root<T> root = update.from((Class<T>) domainClass);
+
+        update.set(DELETED_FIELD, localDateTime);
+
+        final List<Predicate> predicates = new ArrayList<Predicate>();
+
+        if (entityInformation.hasCompositeId()) {
+            for (String s : entityInformation.getIdAttributeNames())
+                predicates.add(cb.equal(root.<ID>get(s),
+                        entityInformation.getCompositeIdAttributeValue(entityInformation.getId(entity), s)));
+            update.where(cb.and(predicates.toArray(new Predicate[predicates.size()])));
+        } else
+            update.where(cb.equal(root.<ID>get(entityInformation.getIdAttribute().getName()),
+                    entityInformation.getId(entity)));
+
+        em.createQuery(update).executeUpdate();
+    }
+
+    public long countActive() {
+        return super.count(notDeleted());
+    }
+
+    @Override
+    public boolean existsActive(ID id) {
+        Assert.notNull(id, "The entity must not be null!");
+        return findOneActive(id) != null ? true : false;
+    }
+
+    private static final class ByIdSpecification<T, ID extends Serializable> implements Specification<T> {
+
+        private final JpaEntityInformation<T, ?> entityInformation;
+        private final ID id;
+
+        public ByIdSpecification(JpaEntityInformation<T, ?> entityInformation, ID id) {
+            this.entityInformation = entityInformation;
+            this.id = id;
+        }
+
+        @Override
+        public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
+            final List<Predicate> predicates = new ArrayList<Predicate>();
+            if (entityInformation.hasCompositeId()) {
+                for (String s : entityInformation.getIdAttributeNames())
+                    predicates.add(cb.equal(root.<ID>get(s), entityInformation.getCompositeIdAttributeValue(id, s)));
+
+                return cb.and(predicates.toArray(new Predicate[predicates.size()]));
+            }
+            return cb.equal(root.<ID>get(entityInformation.getIdAttribute().getName()), id);
+        }
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static final class ByIdsSpecification<T> implements Specification<T> {
+
+        private final JpaEntityInformation<T, ?> entityInformation;
+
+        ParameterExpression<Iterable> parameter;
+
+        public ByIdsSpecification(JpaEntityInformation<T, ?> entityInformation) {
+            this.entityInformation = entityInformation;
+        }
+
+        @Override
+        public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
+            Path<?> path = root.get(entityInformation.getIdAttribute());
+            parameter = cb.parameter(Iterable.class);
+            return path.in(parameter);
+        }
+    }
+
+    private static final class DeletedIsNull<T> implements Specification<T> {
+        @Override
+        public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
+            return cb.isNull(root.<LocalDateTime>get(DELETED_FIELD));
+        }
+    }
+
+    private static final class DeletedTimeGreatherThanNow<T> implements Specification<T> {
+        @Override
+        public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
+            return cb.greaterThan(root.<LocalDateTime>get(DELETED_FIELD), LocalDateTime.now());
+        }
+    }
+
+    private static final <T> Specification<T> notDeleted() {
+        return Specifications.where(new DeletedIsNull<T>()).or(new DeletedTimeGreatherThanNow<T>());
+    }
+
+
+    private static final <T> Specification<T> composeWhereNotDeleted(Specification<T> spec) {
+        return Specifications.where(spec).and(notDeleted());
+    }
 }


### PR DESCRIPTION
## Goal

Be possible to retrieve only "active" items using some rules specified by the repository caller.

## Approach

Expose a `Specification` entry point and compose it with `notDeleted()` in the `find*Active` methods of `SoftDeleteRepository`

Sample:
```java
userRepository.findOneActive((root, query, cb) -> cb.equal(root.get("name"), "jose"));
```

## Other possibilities

Look at the interface bellow
```java
@Repository
@Transactional
public interface UserRepository extends SoftDeletesRepository<User, Long> {

    Optional<User> findActiveByName(String name); // Will retrieve even if softdeleted

    Optional<User> findByActiveAndName(Boolean active, String name); // Needs active flag

    Optional<User> findByDeletedOnGreaterThanOrDeletedOnIsNullAndName(LocalDateTime deletedOn, String name); // long method name

    @Query("SELECT u FROM users u WHERE u.name = ? AND (u.deleted_on > NOW() OR u.deleted_on IS NULL)")
    Optional<User> findActiveByName(String name);
}
```

1) For the first option, we would need to be able to extend the key words of JPA so the `Active` key word would add the `notDeleted()` constraint; I think it is not currently possible to extend the existing key words;

2) For the second option, keep a second flag in each table that would work as filter for deleted items. This approach would require the removal `scheduleSoftDelete` ;

3) Have very long method name and pass a `LocalDateTime` as filter; With this `scheduleSoftDelete` keeps working but is troublesome for the developer to read the method name. I am not sure how JPA groups the constraints and it may be a problem depending of how the OR is evaluated.
4) With the fourth option we have a nice method name to read and we can explicitly say how to evaluate the OR , but need to write all the query by hand for every method;


I don't really know which one it the best approach to keep the code readable and easy to maintain.

